### PR TITLE
Control JDK installation from Puppet Facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ product_profile: Product profile
 environment: Puppet environment
 platform: The platform to use. ex: default, kubernetes, mesos
 use_hieradata: Set to true to use Hiera as the data backend
-install_java: Set to true to install the JDK during the Puppet run.
 pattern: Product pattern as defined in the product Puppet module.
 ```
 
@@ -54,6 +53,5 @@ product_profile: default
 environment: dev
 platform: default
 use_hieradata: false
-install_java: true
 pattern: pattern-0
 ```

--- a/README.md
+++ b/README.md
@@ -29,3 +29,31 @@ Ex: ./setup.sh -p all
 ```
 Finally go to the puppet-base module and checkout the compatible version of puppet-base module with the
 product-module version.
+
+### Required Custom Facts
+
+Following custom Facts are required for the WSO2 Puppet modules to run.
+
+```yaml
+product_name: Product name as defined in the product Puppet module
+product_version: Produce version
+product_profile: Product profile
+environment: Puppet environment
+platform: The platform to use. ex: default, kubernetes, mesos
+use_hieradata: Set to true to use Hiera as the data backend
+install_java: Set to true to install the JDK during the Puppet run.
+pattern: Product pattern as defined in the product Puppet module.
+```
+
+For example, for WSO2 API Manager pattern-0, the following set of Facts can be set.
+
+```yaml
+product_name: wso2am_runtime
+product_version: 2.1.0
+product_profile: default
+environment: dev
+platform: default
+use_hieradata: false
+install_java: true
+pattern: pattern-0
+```

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -19,17 +19,9 @@
 # Default node definition
 node "default" {
   if $::use_hieradata == "true" {
-    if $::install_java == "true"
-      require wso2base::java
-    }
-
     hiera_include('classes')
 
   } else {
-    if $::install_java == "true"
-      class { '::wso2base::java': } -> class { "::${::product_name}": }
-    } else {
-      class { "::${::product_name}": }
-    }
+    class { "::${::product_name}": }
   }
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -19,10 +19,17 @@
 # Default node definition
 node "default" {
   if $::use_hieradata == "true" {
-    require wso2base::java
+    if $::install_java == "true"
+      require wso2base::java
+    }
+
     hiera_include('classes')
 
   } else {
-    class { '::wso2base::java': } -> class { "::${::product_name}": }
+    if $::install_java == "true"
+      class { '::wso2base::java': } -> class { "::${::product_name}": }
+    } else {
+      class { "::${::product_name}": }
+    }
   }
 }

--- a/vagrant/config.yaml.sample
+++ b/vagrant/config.yaml.sample
@@ -24,6 +24,7 @@ servers:
       environment: dev
       platform: default
       use_hieradata: false
+      install_java: true
       pattern: pattern-0
     box: ubuntu/trusty64
     ip: 192.168.100.2
@@ -40,6 +41,7 @@ servers:
 #     environment: dev
 #     platform: default
 #     use_hieradata: true
+#     install_java: true
 #     pattern: pattern-1
 #   box: ubuntu/trusty64
 #   ip: 192.168.100.3

--- a/vagrant/config.yaml.sample
+++ b/vagrant/config.yaml.sample
@@ -24,7 +24,6 @@ servers:
       environment: dev
       platform: default
       use_hieradata: false
-      install_java: true
       pattern: pattern-0
     box: ubuntu/trusty64
     ip: 192.168.100.2
@@ -41,7 +40,6 @@ servers:
 #     environment: dev
 #     platform: default
 #     use_hieradata: true
-#     install_java: true
 #     pattern: pattern-1
 #   box: ubuntu/trusty64
 #   ip: 192.168.100.3


### PR DESCRIPTION
This PR introduces a new Custom Fact named `install_java` with possible boolean values `true` and `false`. This fact controls the Puppet logic so that if set to `true`, Puppet will install JDK along with the product in the Puppet run itself. If set to `false`, Puppet will not install the JDK. 

This change is crucial for scenarios where the instances that Puppet run in already have a JDK installed and do not want to depend on a Puppet introduced JDK. 

This resolves #12 

> NOTE: For the complete implementation of the original discussion, I've opened a PR at wso2/puppet-base.
https://github.com/wso2/puppet-base/pull/19 