### PR TITLE
Remove virtualbox group as it fails intermittently

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -60,7 +60,6 @@ Vagrant.configure(2) do |config|
           vb.check_guest_additions = false
           vb.functional_vboxsf = false
           vb.gui = false
-          vb.customize ['modifyvm', :id, '--groups', '/WSO2-Puppet-Dev']
           vb.customize ['modifyvm', :id, '--memory', memory]
           vb.customize ['modifyvm', :id, '--cpus', cpu]
         end


### PR DESCRIPTION
This PR removes the virtualbox group created for grouping all WSO2 virtualbox instances as it fails intermittently and causes to manually delete those folders.