### PR TITLE
Update java version in use

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -21,7 +21,7 @@ Puppet will be used as the provisioning method in Vagrant and Hiera as the confi
 2. Download and copy Oracle JDK `1.8.0_131` distribution to the following path:
 
     ````
-    <PUPPET_HOME>/modules/wso2base/files/jdk-8u112-linux-x64.tar.gz
+    <PUPPET_HOME>/modules/wso2base/files/jdk-8u131-linux-x64.tar.gz
     ````
 
 3. Download and copy required WSO2 product distributions to each Puppet module under `files` folder:

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -18,7 +18,7 @@ Puppet will be used as the provisioning method in Vagrant and Hiera as the confi
 
     Additionally, you can copy a sample `config.yaml` file from the `vagrant-samples` folder found in puppet-<product> repository for quickly running a product on Vagrant.
 
-2. Download and copy Oracle JDK `1.8.0_112` distribution to the following path:
+2. Download and copy Oracle JDK `1.8.0_131` distribution to the following path:
 
     ````
     <PUPPET_HOME>/modules/wso2base/files/jdk-8u112-linux-x64.tar.gz


### PR DESCRIPTION
Java version changed from 1.8.0_112 to 1.8.0_131

## Purpose
Update REAME.md's java version to 1.8.0_131 since the previous version described in the README.md is not the actual version used internally.

Resolves #18 

## Release note
* Update REAME.md's java version to 1.8.0_131